### PR TITLE
Fixes #1

### DIFF
--- a/lib/keycloak/client.ex
+++ b/lib/keycloak/client.ex
@@ -21,6 +21,7 @@ defmodule Keycloak.Client do
     {site, config} = Keyword.pop(config, :site)
 
     [strategy: Keycloak,
+     realm: realm,
      site: "#{site}/auth",
      authorize_url: "/realms/#{realm}/protocol/openid-connect/auth",
      token_url: "/realms/#{realm}/protocol/openid-connect/token"]

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Keycloak.Mixfile do
 
   def project do
     [app: :keycloak,
-     version: "0.2.1",
+     version: "0.2.2",
      elixir: "~> 1.4",
      name: "keycloak",
      description: "Library for interacting with a Keycloak authorization server",


### PR DESCRIPTION
The `realm` was missing from the `config()` due to the `Keyword.pop` call.