### PR TITLE
Make JSON library configurable

### DIFF
--- a/lib/keycloak.ex
+++ b/lib/keycloak.ex
@@ -59,4 +59,16 @@ defmodule Keycloak do
     |> OAuth2.Client.put_header("Accept", "application/json")
     |> AuthCode.get_token(params, headers)
   end
+
+
+  @doc """
+  Returns the configured JSON encoding library for Keycloak.
+  To customize the JSON library, including the following
+  in your `config/config.exs`:
+      config :keycloak, :json_library, Jason
+  """
+  def json_library do
+    Application.get_env(:keycloak, :json_library, Poison)
+  end
+
 end

--- a/lib/keycloak/client.ex
+++ b/lib/keycloak/client.ex
@@ -26,7 +26,7 @@ defmodule Keycloak.Client do
       site: "#{site}/auth",
       authorize_url: "/realms/#{realm}/protocol/openid-connect/auth",
       token_url: "/realms/#{realm}/protocol/openid-connect/token",
-      serializers: %{"application/json" => Poison}
+      serializers: %{"application/json" => Keycloak.json_library()}
     ]
     |> Keyword.merge(config)
   end

--- a/lib/keycloak/plug/verify_token.ex
+++ b/lib/keycloak/plug/verify_token.ex
@@ -41,7 +41,7 @@ defmodule Keycloak.Plug.VerifyToken do
       {:error, message} ->
         conn
         |> put_resp_content_type("application/vnd.api+json")
-        |> send_resp(401, Poison.encode!(%{error: message}))
+        |> send_resp(401, Keycloak.json_library().encode!(%{error: message}))
         |> halt()
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -21,11 +21,12 @@ defmodule Keycloak.Mixfile do
   end
 
   defp deps do
+    has_specific_json_library? = nil != Application.get_env(:keycloak, :json_library)
     [
       {:joken, "~> 2.0"},
       {:oauth2, "~> 2.0"},
       {:plug, "~> 1.4"},
-      {:poison, "~> 4.0"},
+      {:poison, "~> 4.0", optional: has_specific_json_library?},
       {:credo, "~> 1.4", only: [:dev, :test], runtime: false},
       {:ex_doc, "~> 0.26", only: :dev, runtime: false},
       {:rexbug, "~> 1.0", only: :dev, runtime: false}


### PR DESCRIPTION
`ecto`, `phoenix` and others seems to prefer `Jason` over `Poison`. Multiple libraries should not provide the same functionality.
Provide a way for user to select the JSON library to use.