### PR TITLE
Remove "/auth" path from Keycloak site

### DIFF
--- a/lib/keycloak/client.ex
+++ b/lib/keycloak/client.ex
@@ -23,7 +23,7 @@ defmodule Keycloak.Client do
     [
       strategy: Keycloak,
       realm: realm,
-      site: "#{site}/auth",
+      site: site,
       authorize_url: "/realms/#{realm}/protocol/openid-connect/auth",
       token_url: "/realms/#{realm}/protocol/openid-connect/token",
       serializers: %{"application/json" => Poison}


### PR DESCRIPTION
Having the "/auth" path added immediately after the Keycloak site breaks the URLs (results in 404 errors).

See https://www.keycloak.org/docs/latest/securing_apps/#endpoints